### PR TITLE
feat: add exporting android bindings

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -79,3 +79,14 @@ jobs:
                   override: true
             - name: Build iOS xcframework
               run: cd test-e2e && cargo run --bin ios
+    test-android-ffi-build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Install Rust toolchain
+              uses: actions-rs/toolchain@v1
+              with:
+                  toolchain: stable
+                  override: true
+            - name: Build Android bindings
+              run: cd test-e2e && cargo run --bin android

--- a/mopro-ffi/src/app_config/android.rs
+++ b/mopro-ffi/src/app_config/android.rs
@@ -7,13 +7,11 @@ use super::{cleanup_tmp_local, install_arch, install_ndk, mktemp_local};
 pub const MOPRO_KOTLIN: &str = include_str!("../../KotlinBindings/uniffi/mopro/mopro.kt");
 
 pub fn build() {
-    let cwd = std::env::current_dir().unwrap();
+    let cwd = std::env::current_dir().expect("Failed to get current directory");
     let manifest_dir =
-        std::env::var("CARGO_MANIFEST_DIR").unwrap_or(cwd.to_str().unwrap().to_string());
-    let build_dir = format!("{}/build", manifest_dir);
-    let build_dir_path = Path::new(&build_dir);
-    let work_dir = mktemp_local(&build_dir_path);
-    // let kotlin_bindings_dir = work_dir.join(Path::new("KotlinBindings"));
+        std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| cwd.to_str().unwrap().to_string());
+    let build_dir = Path::new(&manifest_dir).join("build");
+    let work_dir = mktemp_local(&build_dir);
     let bindings_out = work_dir.join("MoproAndroidBindings");
     let bindings_dest = Path::new(&manifest_dir).join("MoproAndroidBindings");
 
@@ -24,75 +22,73 @@ pub fn build() {
         "aarch64-linux-android",
     ];
 
-    let mode;
-    if let Ok(configuration) = std::env::var("CONFIGURATION") {
-        mode = match configuration.as_str() {
-            "Debug" => "debug",
-            "Release" => "release",
-            "debug" => "debug",
-            "release" => "release",
-            _ => panic!("unknown configuration"),
-        };
-    } else {
-        mode = "debug";
-    }
+    let mode = std::env::var("CONFIGURATION")
+        .unwrap_or_else(|_| "debug".to_string())
+        .to_lowercase();
+    let mode = match mode.as_str() {
+        "debug" | "release" => mode,
+        _ => panic!("Unknown configuration: {}", mode),
+    };
 
     install_ndk();
     for arch in target_archs {
-        install_arch(arch.to_string());
-        let mut build_cmd = Command::new("cargo");
-        build_cmd.arg("ndk").arg("-t").arg(arch);
-        if mode == "release" {
-            build_cmd.arg("--release");
-        }
-        build_cmd
-            .arg("build")
-            .arg("--lib")
-            .env("CARGO_BUILD_TARGET_DIR", &build_dir)
-            .env("CARGO_BUILD_TARGET", arch)
-            .spawn()
-            .expect("Failed to spawn cargo build")
-            .wait()
-            .expect("cargo build errored");
-
-        let folder: String;
-        match arch {
-            "x86_64-linux-android" => {
-                folder = String::from("x86_64");
-            }
-            "i686-linux-android" => {
-                folder = String::from("x86");
-            }
-            "armv7-linux-androideabi" => {
-                folder = String::from("armeabi-v7a");
-            }
-            "aarch64-linux-android" => {
-                folder = String::from("arm64-v8a");
-            }
-            _ => panic!("Unknown target architecture"),
-        }
-        let out_lib_path = Path::new(&build_dir).join(format!(
-            "{}/{}/{}/libmopro_bindings.so",
-            build_dir, arch, mode
-        ));
-
-        let out_lib_dest = bindings_out.join(format!("jniLibs/{}/libmopro_bindings.so", folder));
-
-        // Create necessary directories and copy the library
-        fs::create_dir_all(out_lib_dest.parent().unwrap())
-            .expect("Failed to create jniLibs directory");
-        fs::copy(&out_lib_path, &out_lib_dest).expect("Failed to copy file");
+        build_for_arch(&arch, &build_dir, &bindings_out, &mode);
     }
 
-    fs::create_dir_all(&bindings_out.join("uniffi").join("mopro"))
-        .expect("Failed to create directory");
+    write_kotlin_bindings(&bindings_out);
+    move_bindings(&bindings_out, &bindings_dest);
+    cleanup_tmp_local(&build_dir);
+}
 
-    fs::write(
-        bindings_out.join("uniffi").join("mopro").join("mopro.kt"),
-        MOPRO_KOTLIN,
-    )
-    .expect("Failed to write mopro.kt");
+fn build_for_arch(arch: &str, build_dir: &Path, bindings_out: &Path, mode: &str) {
+    install_arch(arch.to_string());
 
+    let mut build_cmd = Command::new("cargo");
+    build_cmd
+        .arg("ndk")
+        .arg("-t")
+        .arg(arch)
+        .arg("build")
+        .arg("--lib");
+    if mode == "release" {
+        build_cmd.arg("--release");
+    }
+    build_cmd
+        .env("CARGO_BUILD_TARGET_DIR", build_dir)
+        .env("CARGO_BUILD_TARGET", arch)
+        .spawn()
+        .expect("Failed to spawn cargo build")
+        .wait()
+        .expect("cargo build errored");
+
+    let folder = match arch {
+        "x86_64-linux-android" => "x86_64",
+        "i686-linux-android" => "x86",
+        "armv7-linux-androideabi" => "armeabi-v7a",
+        "aarch64-linux-android" => "arm64-v8a",
+        _ => panic!("Unknown target architecture: {}", arch),
+    };
+
+    let out_lib_path = build_dir.join(format!(
+        "{}/{}/{}/libmopro_bindings.so",
+        build_dir.display(),
+        arch,
+        mode
+    ));
+    let out_lib_dest = bindings_out.join(format!("jniLibs/{}/libuniffi_mopro.so", folder));
+
+    fs::create_dir_all(out_lib_dest.parent().unwrap()).expect("Failed to create jniLibs directory");
+    fs::copy(&out_lib_path, &out_lib_dest).expect("Failed to copy file");
+}
+
+fn write_kotlin_bindings(bindings_out: &Path) {
+    let mopro_kt_path = bindings_out.join("uniffi/mopro/mopro.kt");
+    fs::create_dir_all(mopro_kt_path.parent().unwrap())
+        .expect("Failed to create uniffi/mopro directory");
+    fs::write(&mopro_kt_path, MOPRO_KOTLIN).expect("Failed to write mopro.kt");
+}
+
+fn move_bindings(bindings_out: &Path, bindings_dest: &Path) {
     if let Ok(info) = fs::metadata(&bindings_dest) {
         if !info.is_dir() {
             panic!("bindings directory exists and is not a directory");
@@ -100,5 +96,4 @@ pub fn build() {
         fs::remove_dir_all(&bindings_dest).expect("Failed to remove bindings directory");
     }
     fs::rename(&bindings_out, &bindings_dest).expect("Failed to move bindings into place");
-    cleanup_tmp_local(&build_dir_path)
 }

--- a/mopro-ffi/src/app_config/android.rs
+++ b/mopro-ffi/src/app_config/android.rs
@@ -2,12 +2,13 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
+use crate::app_config::install_ndk;
+
 use super::{install_arch, mktemp_local};
 
 pub const MOPRO_KOTLIN: &str = include_str!("../../KotlinBindings/uniffi/mopro/mopro.kt");
 
 pub fn build() {
-    println!("Building Android bindings");
     let cwd = std::env::current_dir().unwrap();
     let manifest_dir =
         std::env::var("CARGO_MANIFEST_DIR").unwrap_or(cwd.to_str().unwrap().to_string());
@@ -38,8 +39,8 @@ pub fn build() {
         mode = "debug";
     }
 
+    install_ndk();
     for arch in target_archs {
-        println!("Building for {}", arch);
         install_arch(arch.to_string());
         let mut build_cmd = Command::new("cargo");
         build_cmd.arg("ndk").arg("-t").arg(arch);
@@ -76,7 +77,6 @@ pub fn build() {
             "{}/{}/{}/libmopro_bindings.so",
             build_dir, arch, mode
         )));
-        println!("{:?}", out_lib_path);
 
         if !bindings_dest.exists() {
             fs::create_dir_all(&bindings_out).expect("Failed to create directory");

--- a/mopro-ffi/src/app_config/android.rs
+++ b/mopro-ffi/src/app_config/android.rs
@@ -1,0 +1,127 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use super::{install_arch, mktemp_local};
+
+pub const MOPRO_KOTLIN: &str = include_str!("../../KotlinBindings/uniffi/mopro/mopro.kt");
+
+pub fn build() {
+    println!("Building Android bindings");
+    let cwd = std::env::current_dir().unwrap();
+    let manifest_dir =
+        std::env::var("CARGO_MANIFEST_DIR").unwrap_or(cwd.to_str().unwrap().to_string());
+    let build_dir = format!("{}/build", manifest_dir);
+    let build_dir_path = Path::new(&build_dir);
+    let work_dir = mktemp_local(&build_dir_path);
+    // let kotlin_bindings_dir = work_dir.join(Path::new("KotlinBindings"));
+    let bindings_out = work_dir.join("MoproAndroidBindings");
+    let bindings_dest = Path::new(&manifest_dir).join("MoproAndroidBindings");
+
+    let target_archs = vec![
+        "x86_64-linux-android",
+        "i686-linux-android",
+        "armv7-linux-androideabi",
+        "aarch64-linux-android",
+    ];
+
+    let mode;
+    if let Ok(configuration) = std::env::var("CONFIGURATION") {
+        mode = match configuration.as_str() {
+            "Debug" => "debug",
+            "Release" => "release",
+            "debug" => "debug",
+            "release" => "release",
+            _ => panic!("unknown configuration"),
+        };
+    } else {
+        mode = "debug";
+    }
+
+    for arch in target_archs {
+        println!("Building for {}", arch);
+        install_arch(arch.to_string());
+        let mut build_cmd = Command::new("cargo");
+        build_cmd.arg("ndk").arg("-t").arg(arch);
+        if mode == "release" {
+            build_cmd.arg("--release");
+        }
+        build_cmd
+            .arg("build")
+            .arg("--lib")
+            .env("CARGO_BUILD_TARGET_DIR", &build_dir)
+            .env("CARGO_BUILD_TARGET", arch)
+            .spawn()
+            .expect("Failed to spawn cargo build")
+            .wait()
+            .expect("cargo build errored");
+
+        let folder: String;
+        match arch {
+            "x86_64-linux-android" => {
+                folder = String::from("x86_64");
+            }
+            "i686-linux-android" => {
+                folder = String::from("x86");
+            }
+            "armv7-linux-androideabi" => {
+                folder = String::from("armeabi-v7a");
+            }
+            "aarch64-linux-android" => {
+                folder = String::from("arm64-v8a");
+            }
+            _ => panic!("Unknown target architecture"),
+        }
+        let out_lib_path = Path::new(&build_dir).join(Path::new(&format!(
+            "{}/{}/{}/libmopro_bindings.so",
+            build_dir, arch, mode
+        )));
+        println!("{:?}", out_lib_path);
+
+        if !bindings_dest.exists() {
+            fs::create_dir_all(&bindings_out).expect("Failed to create directory");
+        }
+        if !bindings_dest.join(Path::new("jniLibs")).exists() {
+            fs::create_dir_all(bindings_out.join(Path::new("jniLibs")))
+                .expect("Failed to create directory");
+        }
+        if !bindings_dest
+            .join(Path::new("jniLibs"))
+            .join(Path::new(&folder))
+            .exists()
+        {
+            fs::create_dir_all(
+                bindings_dest
+                    .join(Path::new("jniLibs"))
+                    .join(Path::new(&folder)),
+            )
+            .expect("Failed to create directory");
+        }
+        let out_lib_dest = bindings_dest.join(Path::new(&format!(
+            "jniLibs/{}/libmopro_bindings.so",
+            folder
+        )));
+        fs::copy(&out_lib_path, &out_lib_dest).expect("Failed to copy file");
+
+        if !bindings_dest
+            .join(Path::new("uniffi"))
+            .join(Path::new("mopro"))
+            .exists()
+        {
+            fs::create_dir_all(
+                &bindings_dest
+                    .join(Path::new("uniffi"))
+                    .join(Path::new("mopro")),
+            )
+            .expect("Failed to create directory");
+        }
+        fs::write(
+            bindings_dest
+                .join(Path::new("uniffi"))
+                .join(Path::new("mopro"))
+                .join("mopro.kt"),
+            MOPRO_KOTLIN,
+        )
+        .expect("Failed to write mopro.swift");
+    }
+}

--- a/mopro-ffi/src/app_config/mod.rs
+++ b/mopro-ffi/src/app_config/mod.rs
@@ -4,6 +4,7 @@ use std::process::Command;
 use uuid::Uuid;
 
 pub mod ios;
+pub mod android;
 
 pub fn mktemp() -> PathBuf {
     let dir = std::env::temp_dir().join(Path::new(&Uuid::new_v4().to_string()));

--- a/mopro-ffi/src/app_config/mod.rs
+++ b/mopro-ffi/src/app_config/mod.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use uuid::Uuid;
 
-pub mod ios;
 pub mod android;
+pub mod ios;
 
 pub fn mktemp() -> PathBuf {
     let dir = std::env::temp_dir().join(Path::new(&Uuid::new_v4().to_string()));
@@ -35,6 +35,16 @@ pub fn cleanup_tmp_local(build_path: &Path) {
 }
 
 pub const UDL: &str = include_str!("../mopro.udl");
+
+pub fn install_ndk() {
+    Command::new("cargo")
+        .arg("install")
+        .arg("cargo-ndk")
+        .spawn()
+        .expect("Failed to spawn cargo, is it installed?")
+        .wait()
+        .expect("Failed to install cargo-ndk");
+}
 
 pub fn install_arch(arch: String) {
     Command::new("rustup")

--- a/test-e2e/.gitignore
+++ b/test-e2e/.gitignore
@@ -1,2 +1,3 @@
 *.udl
 build/
+MoproAndroidBindings/

--- a/test-e2e/Cargo.toml
+++ b/test-e2e/Cargo.toml
@@ -10,6 +10,9 @@ crate-type = ["lib", "cdylib", "staticlib"]
 [[bin]]
 name = "ios"
 
+[[bin]]
+name = "android"
+
 [features]
 default = ["mopro-ffi/circom"]
 

--- a/test-e2e/src/bin/android.rs
+++ b/test-e2e/src/bin/android.rs
@@ -1,0 +1,3 @@
+fn main() {
+    mopro_ffi::app_config::android::build();
+}


### PR DESCRIPTION
- it should output a `jniLibs/` folder and a `uniffi/mopro` folder in `MoproAndroidBindings` direcotry
- ref
    - https://zkmopro.org/docs/circom/android#getting-started-with-exported-bindings
    - https://forgen.tech/en/blog/post/building-an-android-app-with-rust-using-uniffi
    - https://sal.dev/android/intro-rust-android-uniffi/
- not sure if there is a way to create like `xcframework`
- don't know what is the difference between the ios `framework_out` and `framework_dest`?